### PR TITLE
Adds title as group name

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
 	"name": "Tabius - Automatic Tab Grouping Assistant",
 	"short_name": "Tabius",
 	"description": "An Automatic Tab Grouping Extension for Your Browser.",
-	"version": "2.0",
+	"version": "2.0.1",
 	"author": "Faisal Ahmed",
 	"background": {
 		"service_worker": "assets/background.js",

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -37,6 +37,7 @@ async function createTab(newtab: chrome.tabs.Tab) {
 
 	//this options is used to create a new tab group down the road
 
+	//TODO: fix the type warning
 	const options: chrome.tabs.GroupOptions = {
 		tabIds: [tab.id, tab.openerTabId], //creates a new tab group with the new tab and the opener tab
 	};
@@ -167,7 +168,8 @@ async function createTab(newtab: chrome.tabs.Tab) {
 				} else {
 					//we choose something dependingn on the domain rule
 					tabgroupName = await getDomain(
-						openerTabInfo?.pendingUrl ?? openerTabInfo?.url
+						openerTabInfo?.pendingUrl ?? openerTabInfo?.url,
+						openerTabInfo
 					); //getting original tab's url and checking if it's pending
 				}
 
@@ -185,11 +187,11 @@ async function createTab(newtab: chrome.tabs.Tab) {
 				}
 				// updating the group after creation
 				try {
-					const groupUpdated = await chrome.tabGroups.update(
+					const _groupUpdated = await chrome.tabGroups.update(
 						groupId,
 						updateProperties
 					);
-					// console.log(groupUpdated);
+					// console.log(_groupUpdated);
 				} catch (error) {
 					// console.log(error, groupId, tabgroupName);
 				}
@@ -207,7 +209,7 @@ async function createTab(newtab: chrome.tabs.Tab) {
 	}
 }
 
-async function getDomain(url?: string) {
+async function getDomain(url?: string, openerTab?: chrome.tabs.Tab) {
 	if (!url) {
 		return;
 	}
@@ -236,6 +238,9 @@ async function getDomain(url?: string) {
 		case "nameless":
 			return "";
 
+		case "title":
+			return openerTab?.title ? getOgSiteTitle(openerTab) : justDomain(); //in case the title is empty, we return the domain
+
 		default:
 			return justDomain();
 	}
@@ -246,6 +251,12 @@ async function getDomain(url?: string) {
 		}
 		return fragments[0];
 	}
+}
+
+function getOgSiteTitle(tab: chrome.tabs.Tab) {
+	//have to limit the title to some chars in future version?
+	//currently Chrome will truncate it anyway
+	return tab.title;
 }
 
 export function getHostname(url?: string) {

--- a/src/const.ts
+++ b/src/const.ts
@@ -82,7 +82,12 @@ export async function setMultipleStorageObjects(items: StorageObject[]) {
 }
 
 export type GROUP_BY = "sot" | "sd";
-export type GROUP_NAMING = "dom" | "subdom" | "subdomtld" | "nameless";
+export type GROUP_NAMING =
+	| "dom"
+	| "subdom"
+	| "subdomtld"
+	| "nameless"
+	| "title";
 
 export type BlockList = {
 	id: string;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -35,6 +35,7 @@ export async function addUrlToBlocklist(url?: string) {
 	if (!origin) return false;
 
 	try {
+		//todo: fix the type warning
 		const { blocklist } = await getOneStorageItem("blocklist");
 		const newSite: BlockList = {
 			id: id,
@@ -57,6 +58,7 @@ export async function deleteUrlFromBlocklist(url?: string) {
 	if (!url) return false;
 
 	try {
+		//todo: fix the type warning
 		const { blocklist } = await getOneStorageItem("blocklist"); //chrome.storage.sync.get([K_BLOCK_LIST]);
 		const rules: BlockList[] = blocklist?.filter(
 			(item: BlockRule) => getHostname(item.blockedUrl) !== getHostname(url)

--- a/src/options/Settings.tsx
+++ b/src/options/Settings.tsx
@@ -199,6 +199,7 @@ const Settings = () => {
 						<option value="dom">domain</option>
 						<option value="subdom">subdomain.domain</option>
 						<option value="subdomtld">subdomain.domain.tld</option>
+						<option value="title">Group opener's title</option>
 						<option value="nameless">nameless (no name)</option>
 					</select>
 				</div>


### PR DESCRIPTION
This PR adds the opener tab's title as an option for the tab group name.
As requested by @gustavotrott in https://github.com/FaisalBinAhmed/tabius/issues/1

Currently, it takes the full title, but in the future, I might decide to truncate it but need to figure out an optimal criterion for that. Chrome only shows the truncated title as the group name anyway. 

<img width="1237" alt="image" src="https://github.com/FaisalBinAhmed/tabius/assets/20614782/03eb316c-8eb6-46ba-954f-b6bb851dc943">
