### PR TITLE
fix(background): Fix window selection issue when creating new tab groups

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -69,6 +69,10 @@ async function createTab(newtab: chrome.tabs.Tab) {
 	if (openerTabInfo?.groupId !== -1) {
 		options.groupId = openerTabInfo?.groupId;
 		newGroup = false;
+	} else {
+		options.createProperties = {
+			windowId: openerTabInfo?.windowId, // make sure that the new group is in the same window as the opener tab
+		};
 	}
 	// console.log(newGroup, "new group");
 	// console.log(options);


### PR DESCRIPTION
Added code to ensure the new group is created in the same window as the opening tab

see #12 